### PR TITLE
Fix spawning executable on windows

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -154,7 +154,14 @@ connection.onDidChangeWatchedFiles(_change => {
 class TLNotFoundError extends Error { /* ... */ }
 
 async function runTLCheck(filePath: string): Promise<string> {
-	let child = spawn('tl', ["check", filePath]);
+	let child: any;
+
+	let platform = process.platform;
+	if (platform == "win32") {
+		child = spawn('cmd.exe', ['/c', 'tl.bat', "check", filePath]);
+	} else {
+		child = spawn('tl', ["check", filePath]);
+	}
 
 	return await new Promise(async function (resolve, reject) {
 		let stdout = "";


### PR DESCRIPTION
According to documentation [https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows](url) made quick modification. Installing teal lang with `luarocks install tl` on windows creates .bat file not .exe