### PR TITLE
Associate diagnostics with the offending file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,10 +8,7 @@
 			"name": "Launch Client",
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-			"outFiles": [
-				"${workspaceRoot}/out/client/**/*.js",
-				"${workspaceRoot}/out/server/**/*.js",
-			],
+			"outFiles": ["${workspaceRoot}/out/client/**/*.js"],
 			"preLaunchTask": {
 				"type": "npm",
 				"script": "watch"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,10 @@
 			"name": "Launch Client",
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-			"outFiles": ["${workspaceRoot}/out/client/**/*.js"],
+			"outFiles": [
+				"${workspaceRoot}/out/client/**/*.js",
+				"${workspaceRoot}/out/server/**/*.js",
+			],
 			"preLaunchTask": {
 				"type": "npm",
 				"script": "watch"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
             "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA=="
         },
         "@types/vscode": {
-            "version": "1.43.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
-            "integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
+            "version": "1.45.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.1.tgz",
+            "integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
             "dev": true
         },
         "balanced-match": {
@@ -161,6 +161,11 @@
             "version": "3.15.1",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
             "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+        },
+        "vscode-uri": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+            "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
         "tmp-promise": "^2.0.2",
         "vscode-languageclient": "^6.1.3",
         "vscode-languageserver": "^6.1.1",
-        "vscode-languageserver-textdocument": "^1.0.1"
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-uri": "^2.1.2"
     },
     "devDependencies": {
         "@types/vscode": "^1.43.0"


### PR DESCRIPTION
For each error that `tl check` returns, check if the file is either:
    * our tmp buffer (the file that generated the request)
    * any of the other files that are present at that exact path in the workspace

associate the diagnostics with that uri and call `connection.sendDiagnostics` per-uri